### PR TITLE
Update tc_donor_mini.ino

### DIFF
--- a/tc_donor_mini.ino
+++ b/tc_donor_mini.ino
@@ -6,7 +6,8 @@
 #include <ESP8266WiFi.h>
 
 #define wifi_ssid "vtrust-flash"
-#define wifi_password "flashmeifyoucan"
+//#define wifi_password "flashmeifyoucan"
+#define wifi_password ""
 
 #define LED 2
 
@@ -26,7 +27,7 @@ void setup_wifi() {
   delay(10);
   // We start by connecting to a WiFi network
   Serial.println();
-  Serial.print("Connecting to ");
+  Serial.print("(V1.0) Connecting to ");
   Serial.println(wifi_ssid);
   WiFi.persistent(false);
   WiFi.forceSleepWake();
@@ -67,6 +68,7 @@ void loop() {
     digitalWrite(LED, HIGH);
     if(wifiConnected) Serial.println("Disconnected!");
     wifiConnected = false;
-    blink(2,250);
+    blink(2,250);    
+    setup_wifi();
   }
 }


### PR DESCRIPTION
There were two issues addressed. 
1. The newest 'vtrust-flash' ssid does not use a password. All I did was create a blank password.

2. After a connect and then disconnect, the loop would not try to connect again. It looks like the loop is not started till the first connect, so I added a call to the setup_wifi() after a disconnect. That should hold the loop till the next connection.