### PR TITLE
Update tc_donor_mini.ino

### DIFF
--- a/tc_donor_mini.ino
+++ b/tc_donor_mini.ino
@@ -6,7 +6,7 @@
 #include <ESP8266WiFi.h>
 
 #define wifi_ssid "vtrust-flash"
-#define wifi_password "flashmeifyoucan"
+#define wifi_password ""
 
 #define LED 2
 


### PR DESCRIPTION
removed the password, based on the latest (2020-04-26) tuya convert methods.

Tuya removed the password required to join the wifi, so this would no longer, without removing the password.

Tested 202-04-26

BIN file will need to be updated as well.